### PR TITLE
Use latest scissors with `compiledCssExtension: replace`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
 dev_dependencies:
   angular2_testing: '^2.0.0-beta.0'
   browser: ^0.10.0
-  scissors: ^0.2.2
+  scissors: ^0.4.0
   postcss_transformer: '^0.1.1'
   test: '^0.12.6+2'
   grinder: '^0.8.0+1'
@@ -18,8 +18,9 @@ dev_dependencies:
   peanut: '^0.0.1+2'
   dart_to_js_script_rewriter: '^0.1.0+4'
 transformers:
-- sass
-#- scissors
+# - sass
+- scissors:
+    compiledCssExtension: replace
 - postcss_transformer:
     arguments:
     - use: autoprefixer


### PR DESCRIPTION
Hey Kasper, this is just to let you know that the latest release of [sCiSSors](https://github.com/google/dart-scissors) supports the `button.scss` -> `button.css` pattern you're using in one component
